### PR TITLE
Ignore wallet output

### DIFF
--- a/cothority.transfer-coin
+++ b/cothority.transfer-coin
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 
-bin/wallet transfer 1 9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3
+bin/wallet transfer 1 9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3 > /dev/null


### PR DESCRIPTION
The latest version of `wallet` outputs some strings to stdout which makes graphite fail.