### PR TITLE
CI: deploy only if lint was successful

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - uses: kielabokkie/ssh-key-and-known-hosts-action@v1.1.0


### PR DESCRIPTION
According to [the doc](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run):
> A workflow run is triggered regardless of the result of the previous workflow.

This adds a conditional to only deploy if the previous workflow (lint) was successful.