### PR TITLE
Don't expose port 2003 beyond the graphite container

### DIFF
--- a/bin/send-to-graphite
+++ b/bin/send-to-graphite
@@ -1,6 +1,6 @@
 #!/bin/sh -eu
 
-readonly GRAPHITE_HOST=localhost
+readonly GRAPHITE_HOST=$( docker container inspect -f '{{ .NetworkSettings.Networks.stats_stats.IPAddress }}' stats_graphite_1 )
 readonly GRAPHITE_PORT=2003
 
 exec nc -N "$GRAPHITE_HOST" "$GRAPHITE_PORT"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ version: "3.5"
 services:
   graphite:
     image: graphiteapp/graphite-statsd:latest
-    ports:
-      - "2003:2003"
+    expose:
+      - "2003"
     networks:
       - stats
     volumes:


### PR DESCRIPTION
Currently, the `graphite` container exports port 2003 to the host, which maps it also on 2003 (making it theoretically accessible from the outside as well, barring firewalls).
My understanding is that this port is needed from the outside only by the `send-to-graphite` script. This change exposes 2003 only to the host (without mapping), and modifies the script to access the container through the internal network.