### PR TITLE
bin/cas-test: fix path

### DIFF
--- a/bin/cas-test
+++ b/bin/cas-test
@@ -1,1 +1,1 @@
-../src/omniledger/webapp/cas/cmd/cas-test/cas-test
+../src/omniledger/webapp/cas/cas-test


### PR DESCRIPTION
It was pointing to a by hand `go build` path. Use the one from make