### PR TITLE
website.hits: stats.c4dt.org is an alias

### DIFF
--- a/website.hits
+++ b/website.hits
@@ -1,7 +1,7 @@
 #!/bin/sh -eu
 
 readonly CURSOR_FILE=data/websites-cursor
-readonly STATS_IP=`host -t A stats.c4dt.org | cut -d ' ' -f 4`
+readonly STATS_IP=`dig +short stats.c4dt.org | tail -n1`
 
 cursor=`cat $CURSOR_FILE || echo 0`
 


### PR DESCRIPTION
stats.c4dt.org is now an alias to switch.c4dt.org. Correctly resolve its address in website.hits.