### PR TITLE
github/deploy: trigger on push to main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,10 +5,8 @@ env:
   DEPLOY_HOST: stats.c4dt.org
 
 on:
-  workflow_run:
-    workflows: ["lint"]
+  push:
     branches: [main]
-    types: [completed]
 
 jobs:
   deploy:


### PR DESCRIPTION
Hum, deployement wasn't triggered correctly as it expected the "lint" workflow to finish before doing it. We now assume that it is run when PR'ing and not when pushing to "main", so updating trigger to deploy anyway.