### PR TITLE
website.hits: rm from dashboard

### DIFF
--- a/dashboards-to-provision/websites.dashboard.py
+++ b/dashboards-to-provision/websites.dashboard.py
@@ -2,7 +2,7 @@
 
 from common import DASHBOARD_TIME_SPAN, simple_graph
 from grafanalib import formatunits as UNITS
-from grafanalib.core import Dashboard, GridPos, Heatmap, HeatmapColor, Target
+from grafanalib.core import Dashboard, GridPos
 
 dashboard = Dashboard(
     title="websites",
@@ -55,20 +55,6 @@ dashboard = Dashboard(
             UNITS.SECONDS,
             frequency=1,
             alert_at=1,
-        ),
-        Heatmap(
-            title="websites hits",
-            gridPos=GridPos(h=12, w=24, x=0, y=16),
-            targets=[
-                Target(
-                    refId="A",
-                    target="aliasByNode(website.hits.*.count, 2)",
-                ),
-            ],
-            dataFormat="tsbuckets",
-            yBucketBound="middle",
-            reverseYBuckets=True,
-            color=HeatmapColor(mode="opacity", min=0),
         ),
     ],
 ).auto_panel_ids()


### PR DESCRIPTION
Simply removing it from the dashboard. It keeps collecting data and putting it in Graphite but doesn't show it.

Closes: #42