### PR TITLE
systemd/timers: randomize start

### DIFF
--- a/.config/systemd/user/get-and-send-to-graphite:minutely@.timer
+++ b/.config/systemd/user/get-and-send-to-graphite:minutely@.timer
@@ -5,5 +5,9 @@ Description=Run get-and-send-to-graphite@%i each minute
 # OnUnitActiveSec is broken: https://github.com/systemd/systemd/issues/6680
 OnCalendar=minutely
 
+# randomize start to avoid using too much ressources
+AccuracySec=100ms
+RandomizedDelaySec=20s
+
 [Install]
 WantedBy=timers.target

--- a/.config/systemd/user/run-and-send-to-graphite:half-hourly@.timer
+++ b/.config/systemd/user/run-and-send-to-graphite:half-hourly@.timer
@@ -5,5 +5,9 @@ Description=run run-and-send-to-graphite@%i each 30 minutes
 # OnUnitActiveSec is broken: https://github.com/systemd/systemd/issues/6680
 OnCalendar=*:00,30
 
+# randomize start to avoid using too much ressources
+AccuracySec=1s
+RandomizedDelaySec=10m
+
 [Install]
 WantedBy=timers.target

--- a/.config/systemd/user/run-and-send-to-graphite:minutely@.timer
+++ b/.config/systemd/user/run-and-send-to-graphite:minutely@.timer
@@ -5,5 +5,9 @@ Description=run run-and-send-to-graphite@%i each minutes
 # OnUnitActiveSec is broken: https://github.com/systemd/systemd/issues/6680
 OnCalendar=minutely
 
+# randomize start to avoid using too much ressources
+AccuracySec=100ms
+RandomizedDelaySec=20s
+
 [Install]
 WantedBy=timers.target

--- a/.config/systemd/user/time-it-and-send-to-graphite:half-hourly@.timer
+++ b/.config/systemd/user/time-it-and-send-to-graphite:half-hourly@.timer
@@ -4,6 +4,9 @@ Description=Run time-it-and-send-to-graphite@%i each 30 minutes
 [Timer]
 # OnUnitActiveSec is broken: https://github.com/systemd/systemd/issues/6680
 OnCalendar=*:00,30
+
+# randomize start to avoid using too much ressources
+AccuracySec=1s
 RandomizedDelaySec=10m
 
 [Install]

--- a/.config/systemd/user/time-it-and-send-to-graphite:minutely@.timer
+++ b/.config/systemd/user/time-it-and-send-to-graphite:minutely@.timer
@@ -5,5 +5,9 @@ Description=Run time-it-and-send-to-graphite@%i each minute
 # OnUnitActiveSec is broken: https://github.com/systemd/systemd/issues/6680
 OnCalendar=minutely
 
+# randomize start to avoid using too much ressources
+AccuracySec=100ms
+RandomizedDelaySec=20s
+
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
timers are starting at the exact same time, clogging system(d?) ressources. adding a randomized delay stretches reduces load and gives better measures.

btw, that's the first PR to actually be auto deployed by our automagical deployer, a good test :)

Fixes c4dt/TODO#304